### PR TITLE
Order swapped for build_GUI.sh and build_core_modules.sh to prevent f…

### DIFF
--- a/build/build_all.sh
+++ b/build/build_all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ./build_core_kipl.sh
-./build_GUI.sh # needs to be here due to GUI components in modules
 ./build_core_modules.sh
+./build_GUI.sh # needs to be here due to GUI components in modules
 ./build_core_algorithms.sh
 
 ./build_frameworks_tomography.sh


### PR DESCRIPTION
In the course of ubuntu build I encountered the problem with build_all.sh. 
I needed to run twice to compile. This was due to dependency issues. 
The problem has been resolved by simple swapinhg the order of build_GUI.sh and build_core_modules.