### PR TITLE
Added signal blocking solves the unwanted boundary update

### DIFF
--- a/GUI/qt/QtAddons/uxroiwidget.cpp
+++ b/GUI/qt/QtAddons/uxroiwidget.cpp
@@ -17,7 +17,8 @@ uxROIWidget::uxROIWidget(QWidget *parent) :
     roiID(cnt++),
     ui(new Ui::uxROIWidget),
     hViewer(nullptr),
-    autoHideViewerROI(false)
+    autoHideViewerROI(false),
+    allowUpdateImageDims(true)
 {
     ui->setupUi(this);
     setROI(0,0,100,100);
@@ -120,6 +121,11 @@ void uxROIWidget::updateViewer()
         }
 
     }
+}
+
+void uxROIWidget::setAllowUpdateImageDims(bool allow)
+{
+    allowUpdateImageDims=allow;
 }
 
 void uxROIWidget::setROI(size_t *roi, bool ignoreBoundingBox)
@@ -251,7 +257,7 @@ void uxROIWidget::on_valueChanged(int x0,int y0, int x1, int y1)
 
 void uxROIWidget::on_viewerNewImageDims(const QRect &rect)
 {
-    if (hViewer!=nullptr) {
+    if ((allowUpdateImageDims==true) && (hViewer!=nullptr)) {
         setBoundingBox(0,0,rect.width()-1,rect.height()-1);
     }
 

--- a/GUI/qt/QtAddons/uxroiwidget.h
+++ b/GUI/qt/QtAddons/uxroiwidget.h
@@ -83,6 +83,8 @@ public:
     /// \brief Updates the roi rectangle in the viewer
     void updateViewer();
 
+    void setAllowUpdateImageDims(bool allow);
+
 public slots:
     /// \brief A slot the responds to the NewImage signal emitted by the viewer widget. It is used to update the bounding box of the ROI widget.
     void on_viewerNewImageDims(const QRect &rect);
@@ -115,6 +117,7 @@ private:
     ImageViewerWidget * hViewer;
     QString roiColor;
     bool autoHideViewerROI;
+    bool allowUpdateImageDims;
 
 signals:
     void getROIClicked(void); //< signal emitted when the get ROI button is pressen, this can be used with other widgets.

--- a/applications/muhrec3/src/muhrecmainwindow.cpp
+++ b/applications/muhrec3/src/muhrecmainwindow.cpp
@@ -174,6 +174,7 @@ void MuhRecMainWindow::SetupCallBacks()
     ui->widgetMatrixROI->setROIColor("yellow");
     ui->widgetMatrixROI->setTitle("Matrix ROI");
     ui->widgetMatrixROI->setAutoHideROI(true);
+    ui->widgetMatrixROI->setAllowUpdateImageDims(false);
     ui->widgetMatrixROI->updateViewer();
 
     CenterOfRotationChanged();


### PR DESCRIPTION
Added signal blocking for update image dims signal. This prevents the boundaries to be updated for the matrix ROI in MuhRec