### PR TITLE
deploy KipTool in win 10

### DIFF
--- a/build/windows/build_all.bat
+++ b/build/windows/build_all.bat
@@ -1,7 +1,7 @@
-call build_core_kipl.bat
-call build_GUI.bat # needs to be here due to GUI components in modules
-call build_core_modules.bat
+call build_core_kipl.bat 
 call build_core_algorithms.bat
+call build_core_modules.bat
+call build_GUI.bat
 
 call build_frameworks_tomography.bat
 call build_frameworks_imageprocessing.bat


### PR DESCRIPTION
changed order of calls in build all to correctly build projects in Win10