### PR TITLE
Issue381 lblimgcrash

### DIFF
--- a/core/kipl/UnitTests/tkiplmorphalgorithms/tst_kiplmorphalgorithms.cpp
+++ b/core/kipl/UnitTests/tkiplmorphalgorithms/tst_kiplmorphalgorithms.cpp
@@ -104,10 +104,11 @@ void kiplmorphalgorithms::test_LabelImageRealData()
 
     size_t lblCnt=0;
 
-    lblCnt=kipl::morphology::LabelImage(img,result,kipl::base::conn4);
+    lblCnt=kipl::morphology::LabelImage(a,result,kipl::base::conn4);
     qDebug() << lblCnt;
-    lblCnt=kipl::morphology::LabelImage(img,result,kipl::base::conn8);
+    lblCnt=kipl::morphology::LabelImage(a,result,kipl::base::conn8);
     qDebug() << lblCnt;
+    kipl::io::WriteTIFF(result,"lblrealresult_8connect.tif");
 }
 
 void kiplmorphalgorithms::test_RemoveConnectedRegion()

--- a/core/kipl/UnitTests/tkiplmorphalgorithms/tst_kiplmorphalgorithms.cpp
+++ b/core/kipl/UnitTests/tkiplmorphalgorithms/tst_kiplmorphalgorithms.cpp
@@ -46,10 +46,10 @@ kiplmorphalgorithms::~kiplmorphalgorithms()
 
 void kiplmorphalgorithms::loadData()
 {
-#if defined DEBUG
-    kipl::io::ReadTIFF(img,"../../imagingsuite/core/kipl/UnitTests/data/bilevel_ws.tif");
-#else
+#ifdef _NDEBUG
     kipl::io::ReadTIFF(img,"../imagingsuite/core/kipl/UnitTests/data/bilevel_ws.tif");
+#else
+    kipl::io::ReadTIFF(img,"../../imagingsuite/core/kipl/UnitTests/data/bilevel_ws.tif");
 #endif
 }
 
@@ -63,16 +63,35 @@ void kiplmorphalgorithms::test_LabelImage()
     QCOMPARE(img.Size(),result.Size());
     QCOMPARE(lblCnt,24);
 
-    kipl::io::WriteTIFF(result,"lblresult.tif");
+    // Special cases
+    int data[]={   0,0,0,0,0,1,1,0,
+                   1,1,0,0,0,1,1,0,
+                   1,1,0,0,0,0,0,0,
+                   0,0,0,1,1,0,0,0,
+                   0,0,0,1,1,0,0,0,
+                   0,0,0,0,0,0,1,1,
+                   0,1,1,0,0,0,1,1,
+                   0,1,1,0,0,0,0,0
+             };
+
+    size_t dims[2]={8,8};
+    kipl::base::TImage<int,2> s(dims);
+    std::copy_n(data,s.Size(),s.GetDataPtr());
+    lblCnt=kipl::morphology::LabelImage(s,result,kipl::base::conn4);
+    kipl::io::WriteTIFF(result,"lblresult_4x4blocks_4connect.tif");
+
+    lblCnt=kipl::morphology::LabelImage(s,result,kipl::base::conn8);
+    kipl::io::WriteTIFF(result,"lblresult_4x4blocks_8connect.tif");
 
 }
 
 void kiplmorphalgorithms::test_RemoveConnectedRegion()
 {
+    loadData();
     kipl::base::TImage<int,2> result;
     size_t lblCnt=0;
 
-    lblCnt=kipl::morphology::LabelImage(img,result,kipl::base::conn4);
+    lblCnt=kipl::morphology::LabelImage(img,result,kipl::base::conn8);
 
     QCOMPARE(img.Size(),result.Size());
     QCOMPARE(lblCnt,24UL);

--- a/core/kipl/UnitTests/tkiplmorphalgorithms/tst_kiplmorphalgorithms.cpp
+++ b/core/kipl/UnitTests/tkiplmorphalgorithms/tst_kiplmorphalgorithms.cpp
@@ -23,9 +23,12 @@ public:
 
 private slots:
     void test_LabelImage();
+    void test_LabelImageRealData();
     void test_RemoveConnectedRegion();
     void test_LabelledItemsInfo();
     void test_pixdist();
+
+private:
     void test_EuclideanDistance();
     void test_EuclideanDistance2();
 
@@ -85,13 +88,35 @@ void kiplmorphalgorithms::test_LabelImage()
 
 }
 
+void kiplmorphalgorithms::test_LabelImageRealData()
+{
+
+#ifdef _NDEBUG
+    std::string fname="../imagingsuite/core/kipl/UnitTests/data/maskOtsuFilled.tif";
+#else
+    std::string fname="../../imagingsuite/core/kipl/UnitTests/data/maskOtsuFilled.tif";
+#endif
+    kipl::strings::filenames::CheckPathSlashes(fname,false);
+    kipl::base::TImage<int,2> a;
+    kipl::base::TImage<int,2> result;
+
+    kipl::io::ReadTIFF(a,fname.c_str());
+
+    size_t lblCnt=0;
+
+    lblCnt=kipl::morphology::LabelImage(img,result,kipl::base::conn4);
+    qDebug() << lblCnt;
+    lblCnt=kipl::morphology::LabelImage(img,result,kipl::base::conn8);
+    qDebug() << lblCnt;
+}
+
 void kiplmorphalgorithms::test_RemoveConnectedRegion()
 {
     loadData();
     kipl::base::TImage<int,2> result;
     size_t lblCnt=0;
 
-    lblCnt=kipl::morphology::LabelImage(img,result,kipl::base::conn8);
+    lblCnt=kipl::morphology::LabelImage(img,result,kipl::base::conn4);
 
     QCOMPARE(img.Size(),result.Size());
     QCOMPARE(lblCnt,24UL);

--- a/core/kipl/kipl/include/morphology/pixeliterator.h
+++ b/core/kipl/kipl/include/morphology/pixeliterator.h
@@ -115,6 +115,7 @@ public:
 
     int supportedDims();
 
+    std::string reportStatus();
 protected:
     void setupNeighborhoods();
     void setupConn4();


### PR DESCRIPTION
The labelling seems to work on windows and linux now. I didnt test MacOS, but the fix should be good there as well.

Resulting labelling of the white segments: 12 labels and no edge leak.
![lblrealresult_8connect-2](https://user-images.githubusercontent.com/11174364/71899963-2292ff80-315d-11ea-8af7-2fc289afcbd7.png)
