### PR TITLE
Issue246 single image

### DIFF
--- a/GUI/qt/QtModuleConfigure/AddModuleDialog.cpp
+++ b/GUI/qt/QtModuleConfigure/AddModuleDialog.cpp
@@ -93,7 +93,7 @@ int AddModuleDialog::exec()
         #else
             QDir dir;
 
-            if (!dir.exists(appPath+"/../Frameworks"))
+            if (dir.exists(appPath+"/../Frameworks"))
                 appPath += "/../Frameworks";
 
             qfileName = QFileDialog::getOpenFileName(this,tr("Open module library"),appPath,tr("libs (*.dylib | *.so)"));

--- a/applications/kiptool/src/kiptoolmainwindow.cpp
+++ b/applications/kiptool/src/kiptoolmainwindow.cpp
@@ -577,6 +577,18 @@ void KipToolMainWindow::on_actionStart_processing_triggered()
         return;
     }
 
+    if(m_OriginalImage.Size(2)==1){
+
+        QMessageBox mbox;
+        mbox.setStandardButtons(QMessageBox::Ok | QMessageBox::Abort);
+        mbox.setDefaultButton(QMessageBox::Abort);
+        mbox.setText(QString::fromStdString("You have loaded a single image. Please note, most modules are configured to work in 3D. Do you want to continue?"));
+        mbox.setWindowTitle("Sanity check warning");
+        int res_msg=mbox.exec();
+        if (res_msg==QMessageBox::Abort)
+            return;
+    }
+
     if (m_Engine) {
         delete m_Engine;
         m_Engine=nullptr;


### PR DESCRIPTION
In this branch a module dialog is added when pressing start processing, it gives a warning that only a single image is loaded, this is to address issue #246.
The path for Frameworks is furthermore corrected