### PR TITLE
removing -liconv from ImagingAlgorithms.pro to allow build

### DIFF
--- a/core/algorithms/ImagingAlgorithms/qt/ImagingAlgorithms/ImagingAlgorithms.pro
+++ b/core/algorithms/ImagingAlgorithms/qt/ImagingAlgorithms/ImagingAlgorithms.pro
@@ -48,7 +48,7 @@ unix {
         INCLUDEPATH += /opt/local/include/libxml2
         QMAKE_LIBDIR += /opt/local/lib
 
-        LIBS += -L/opt/local/lib/ -lxml2 -larmadillo -ltiff -llapack -lblas -liconv
+        LIBS += -L/opt/local/lib/ -lxml2 -larmadillo -ltiff -llapack -lblas
     }
 
 


### PR DESCRIPTION
To allow the builds I had to remove the -lconv from LIBS