### PR TITLE
Fixed build error/added constexpr

### DIFF
--- a/.github/workflows/Build-multi-OS.yml
+++ b/.github/workflows/Build-multi-OS.yml
@@ -99,8 +99,6 @@ jobs:
     - name: Conan installation
       id: conan
       uses: turtlebrowser/get-conan@main
-      with:
-        version: 2.1.0
 
     - name: Using the builtin GitHub Cache Action for .conan
       id: github-cache-conan

--- a/core/kipl/kipl/include/math/nonlinfit.h
+++ b/core/kipl/kipl/include/math/nonlinfit.h
@@ -131,7 +131,7 @@ public:
 private:
 
 
-    static const int NDONE=4; //Convergence parameters.
+    static constexpr int NDONE=4; //Convergence parameters.
     int maxIterations;
     int ndat, ma, mfit;
 
@@ -168,7 +168,7 @@ public:
     ///
     ///	\param x The input argument
     ///	\param hes The numerical Hessian at x
-    virtual int Hessian(double x, arma::mat &hes);
+    virtual int Hessian(double x, arma::mat & hes);
 
     /// \brief Computes the numerical Jacobian
     ///

--- a/core/kipl/kipl/include/math/nonlinfit.h
+++ b/core/kipl/kipl/include/math/nonlinfit.h
@@ -131,7 +131,7 @@ public:
 private:
 
 
-    static constexpr int NDONE=4; //Convergence parameters.
+    static const int NDONE=4; //Convergence parameters.
     int maxIterations;
     int ndat, ma, mfit;
 

--- a/core/kipl/kipl/src/math/median.cpp
+++ b/core/kipl/kipl/src/math/median.cpp
@@ -85,7 +85,7 @@ inline __m128 SortQuad2(__m128 data)
 
 void median_quick_select_sse(float *arr, const size_t n, float *med)
 {
-	//kipl::base::uFQuad data;
+	kipl::base::uFQuad data;
 	kipl::base::uFQuad sorted;
 	data.q.d=std::numeric_limits<float>::max();
 	__m128 d;

--- a/core/kipl/kipl/src/math/nonlinfit.cpp
+++ b/core/kipl/kipl/src/math/nonlinfit.cpp
@@ -327,9 +327,8 @@ void LevenbergMarquardt::covsrt(arma::mat &covar, Nonlinear::FitFunctionBase &fn
         return 1;
     }
 
-    int Gaussian::Hessian(double x, arma::mat &hes)
+    int Gaussian::Hessian(double x, arma::mat & /*hes*/)
     {
-        (void) hes;
         std::cerr<<"The Hessian is not available"<<std::endl;
         return 1;
 

--- a/core/kipl/kipl/src/math/nonlinfit.cpp
+++ b/core/kipl/kipl/src/math/nonlinfit.cpp
@@ -327,9 +327,9 @@ void LevenbergMarquardt::covsrt(arma::mat &covar, Nonlinear::FitFunctionBase &fn
         return 1;
     }
 
-    int Gaussian::Hessian(double x, arma::mat /*&hes*/)
+    int Gaussian::Hessian(double x, arma::mat &hes)
     {
-
+        (void) hes;
         std::cerr<<"The Hessian is not available"<<std::endl;
         return 1;
 

--- a/profiles/windows_msvc_17_release
+++ b/profiles/windows_msvc_17_release
@@ -4,6 +4,6 @@ arch=x86_64
 build_type=Release
 compiler=msvc
 compiler.cppstd=17
-compiler.version=193
+compiler.version=194
 compiler.runtime=dynamic
 [options]


### PR DESCRIPTION
Fixed build error, added 
```c++
constexpr
``` 
to class member to make it compiler-time constant.