### PR TITLE
Replace FlyCI runners with GitHub runners

### DIFF
--- a/.github/workflows/Build-multi-OS.yml
+++ b/.github/workflows/Build-multi-OS.yml
@@ -50,7 +50,7 @@ jobs:
             clang: 14
             build_type: Release
             build_root: build-imagingsuite/Release
-          - os: flyci-macos-14-m2
+          - os: macos-latest
             c_compiler: clang
             cpp_compiler: clang++
             clang: 15


### PR DESCRIPTION
This PR replaces the use of FlyCI macOS runners with GitHub ones since FlyCI macOS runners will be discontinued effective Sep 30, 2024. 

[Read more about the discontinuation of the FlyCI macOS runners](https://flyci.net/blog/flyci-discontinue-macos-runners?utm_source=site_link&utm_medium=github&utm_campaign=discontinue-runners).