### PR TITLE
BUILD: fix path for sse2neon header file

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -80,7 +80,7 @@ class MuhrecRecipe(ConanFile):
                 sse2neon_dir = StringIO()
                 self.run("brew --prefix sse2neon", stdout=sse2neon_dir)
                 sse2neon = sse2neon_dir.getvalue().strip()
-                copy(self, 'sse2neon.h', os.path.join(sse2neon, "include"), self.lib_folder)
+                copy(self, 'sse2neon/sse2neon.h', os.path.join(sse2neon, "include"), self.lib_folder)
         # dirs_exist_ok was only added in python 3.9
         if sys.version_info[1] > 9:
             shutil.copytree(

--- a/core/algorithms/AdvancedFilters/ISSfilterQ3D.hpp
+++ b/core/algorithms/AdvancedFilters/ISSfilterQ3D.hpp
@@ -19,7 +19,7 @@
 #include <sstream>
 
 #ifdef __aarch64__
-    #include <sse2neon.h>
+    #include <sse2neon/sse2neon.h>
 #else
     #include <xmmintrin.h>
     #include <emmintrin.h>

--- a/core/kipl/kipl/include/base/core/quad.h
+++ b/core/kipl/kipl/include/base/core/quad.h
@@ -4,7 +4,7 @@
 #define QUAD_H_
 
 #ifdef __aarch64__
-    #include <sse2neon.h>
+    #include <sse2neon/sse2neon.h>
 #else
     #include <xmmintrin.h>
     #include <emmintrin.h>

--- a/core/kipl/kipl/include/base/core/sharedbuffer.h
+++ b/core/kipl/kipl/include/base/core/sharedbuffer.h
@@ -14,7 +14,7 @@
 	#pragma clang diagnostic ignored "-Wcast-align"
 	#pragma clang diagnostic ignored "-Wpedantic"
 	#pragma clang diagnostic ignored "-W#warnings"
-		#include <sse2neon.h>
+		#include <sse2neon/sse2neon.h>
 	#pragma clang diagnostic pop
 #else
     #include <xmmintrin.h>

--- a/core/kipl/kipl/include/math/core/image_statistics.hpp
+++ b/core/kipl/kipl/include/math/core/image_statistics.hpp
@@ -5,7 +5,7 @@
 #include <limits>
 #include <cmath>
 #ifdef __aarch64__
-    #include <sse2neon.h>
+    #include <sse2neon/sse2neon.h>
 #else
     #include <xmmintrin.h>
     #include <emmintrin.h>

--- a/core/kipl/kipl/src/base/core/imagearithmetics.cpp
+++ b/core/kipl/kipl/src/base/core/imagearithmetics.cpp
@@ -6,7 +6,7 @@
 	#pragma clang diagnostic ignored "-Wcast-align"
 	#pragma clang diagnostic ignored "-Wpedantic"
 	#pragma clang diagnostic ignored "-W#warnings"
-		#include <sse2neon.h>
+		#include <sse2neon/sse2neon.h>
 	#pragma clang diagnostic pop
 #else
     #include <xmmintrin.h>

--- a/core/kipl/kipl/src/math/LUTbase.cpp
+++ b/core/kipl/kipl/src/math/LUTbase.cpp
@@ -9,7 +9,7 @@
 	#pragma clang diagnostic ignored "-Wcast-align"
 	#pragma clang diagnostic ignored "-Wpedantic"
 	#pragma clang diagnostic ignored "-W#warnings"
-		#include <sse2neon.h>
+		#include <sse2neon/sse2neon.h>
 	#pragma clang diagnostic pop
 #else
     #include <xmmintrin.h>

--- a/core/kipl/kipl/src/math/mathfunctions.cpp
+++ b/core/kipl/kipl/src/math/mathfunctions.cpp
@@ -8,7 +8,7 @@
 	#pragma clang diagnostic ignored "-Wcast-align"
 	#pragma clang diagnostic ignored "-Wpedantic"
 	#pragma clang diagnostic ignored "-W#warnings"
-		#include <sse2neon.h>
+		#include <sse2neon/sse2neon.h>
 	#pragma clang diagnostic pop
 #else
     #include <xmmintrin.h>

--- a/core/kipl/kipl/src/math/median.cpp
+++ b/core/kipl/kipl/src/math/median.cpp
@@ -9,7 +9,7 @@
 	#pragma clang diagnostic ignored "-Wcast-align"
 	#pragma clang diagnostic ignored "-Wpedantic"
 	#pragma clang diagnostic ignored "-W#warnings"
-		#include <sse2neon.h>
+		#include <sse2neon/sse2neon.h>
 	#pragma clang diagnostic pop
 #else
    	#include <xmmintrin.h>

--- a/frameworks/tomography/Backprojectors/FDKBackProjectors/src/fdkbp.cpp
+++ b/frameworks/tomography/Backprojectors/FDKBackProjectors/src/fdkbp.cpp
@@ -13,7 +13,7 @@
 	#pragma clang diagnostic ignored "-Wcast-align"
 	#pragma clang diagnostic ignored "-Wpedantic"
 	#pragma clang diagnostic ignored "-W#warnings"
-		#include <sse2neon.h>
+		#include <sse2neon/sse2neon.h>
 	#pragma clang diagnostic pop
 #else
     #include <xmmintrin.h>

--- a/frameworks/tomography/Backprojectors/FDKBackProjectors/src/fdkbp_single.cpp
+++ b/frameworks/tomography/Backprojectors/FDKBackProjectors/src/fdkbp_single.cpp
@@ -13,7 +13,7 @@
 	#pragma clang diagnostic ignored "-Wcast-align"
 	#pragma clang diagnostic ignored "-Wpedantic"
 	#pragma clang diagnostic ignored "-W#warnings"
-		#include <sse2neon.h>
+		#include <sse2neon/sse2neon.h>
 	#pragma clang diagnostic pop
 #else
     #include <xmmintrin.h>

--- a/frameworks/tomography/Backprojectors/StdBackProjectors/src/MultiProjBP.cpp
+++ b/frameworks/tomography/Backprojectors/StdBackProjectors/src/MultiProjBP.cpp
@@ -17,7 +17,7 @@
 	#pragma clang diagnostic ignored "-Wcast-align"
 	#pragma clang diagnostic ignored "-Wpedantic"
 	#pragma clang diagnostic ignored "-W#warnings"
-		#include <sse2neon.h>
+		#include <sse2neon/sse2neon.h>
 	#pragma clang diagnostic pop
 #else
     #include <xmmintrin.h>

--- a/frameworks/tomography/Backprojectors/StdBackProjectors/src/MultiProjBPparallel.cpp
+++ b/frameworks/tomography/Backprojectors/StdBackProjectors/src/MultiProjBPparallel.cpp
@@ -24,7 +24,7 @@
 	#pragma clang diagnostic ignored "-Wcast-align"
 	#pragma clang diagnostic ignored "-Wpedantic"
 	#pragma clang diagnostic ignored "-W#warnings"
-		#include <sse2neon.h>
+		#include <sse2neon/sse2neon.h>
 	#pragma clang diagnostic pop
 #else
     #include <xmmintrin.h>

--- a/frameworks/tomography/Backprojectors/StdBackProjectors/src/NNMultiProjBP.cpp
+++ b/frameworks/tomography/Backprojectors/StdBackProjectors/src/NNMultiProjBP.cpp
@@ -17,7 +17,7 @@
 	#pragma clang diagnostic ignored "-Wcast-align"
 	#pragma clang diagnostic ignored "-Wpedantic"
 	#pragma clang diagnostic ignored "-W#warnings"
-		#include <sse2neon.h>
+		#include <sse2neon/sse2neon.h>
 	#pragma clang diagnostic pop
 #else
     #include <xmmintrin.h>

--- a/frameworks/tomography/Preprocessing/StdPreprocModules/src/SpotClean.cpp
+++ b/frameworks/tomography/Preprocessing/StdPreprocModules/src/SpotClean.cpp
@@ -16,7 +16,7 @@
 #include <morphology/morphfilters.h>
 
 #ifdef __aarch64__
-    #include <sse2neon.h>
+    #include <sse2neon/sse2neon.h>
 #else
     #include <xmmintrin.h>
     #include <emmintrin.h>

--- a/frameworks/tomography/Preprocessing/StdPreprocModules/src/SpotClean2.cpp
+++ b/frameworks/tomography/Preprocessing/StdPreprocModules/src/SpotClean2.cpp
@@ -12,7 +12,7 @@
 	#pragma clang diagnostic ignored "-Wcast-align"
 	#pragma clang diagnostic ignored "-Wpedantic"
 	#pragma clang diagnostic ignored "-W#warnings"
-		#include <sse2neon.h>
+		#include <sse2neon/sse2neon.h>
 	#pragma clang diagnostic pop
 #else
     #include <xmmintrin.h>


### PR DESCRIPTION
Fixes https://github.com/neutronimaging/imagingsuite/issues/734

Correctly copies over the header file.

I tried a conan build locally and it worked.

cc @damskii9992 