### PR TITLE
Bump Intel-based Mac runners from MacOS 12 to MacOS 13 in CI

### DIFF
--- a/.github/workflows/Build-multi-OS.yml
+++ b/.github/workflows/Build-multi-OS.yml
@@ -27,7 +27,7 @@ jobs:
       # Build on the following 4 configurations: 
       # 1. <Windows, Release, 2022 MSVC compiler toolchain>
       # 2. <Ubuntu latest, i.e. version 22.04, Release, GCC 11 compiler toolchain>
-      # 3. <MacOS 12 with x86-64 arch, Release, Clang 14 compiler toolchain>
+      # 3. <MacOS 13 with x86-64 arch, Release, Clang 14 compiler toolchain>
       # 4. <MacOS 14 with arm64 arch, Release, Clang 15 compiler toolchain
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the list.
       matrix:
@@ -44,7 +44,7 @@ jobs:
             gcc: 11
             build_type: Release
             build_root: build-imagingsuite/Release
-          - os: macos-12
+          - os: macos-13
             c_compiler: clang
             cpp_compiler: clang++
             clang: 14

--- a/.github/workflows/Build-wheels.yml
+++ b/.github/workflows/Build-wheels.yml
@@ -28,12 +28,12 @@ jobs:
       # Build on the following 4 configurations: 
       # 1. <Windows, Release, 2022 MSVC compiler toolchain>
       # 2. <Ubuntu latest, i.e. version 22.04, Release, GCC 11 compiler toolchain>
-      # 3. <MacOS 11 with x86-64 arch, Release, Clang 13 compiler toolchain>
+      # 3. <MacOS 13 with x86-64 arch, Release, Clang 14 compiler toolchain>
       # 4. <MacOS 14 with arm64 arch, Release, Clang 15 compiler toolchain
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the list.
       matrix: # Qt requires py7zr==0.20.x which requires python 3.7^
         python-version: ["3.7","3.8","3.9", "3.10", "3.11", "3.12"]
-        os: [windows-2022, ubuntu-latest, macos-12, macos-14]
+        os: [windows-2022, ubuntu-latest, macos-13, macos-14]
         include:
           - os: windows-2022
             c_compiler: cl
@@ -47,7 +47,7 @@ jobs:
             gcc: 11
             build_type: Release
             build_root: build-imagingsuite/Release
-          - os: macos-12
+          - os: macos-13
             c_compiler: clang
             cpp_compiler: clang++
             clang: 14


### PR DESCRIPTION
The GitHub hosted Intel-based Mac runners are bumped from MacOS 12 to MacOS 13