### PR TITLE
Add a testing conan profile for Linux

### DIFF
--- a/profiles/linux_gcc_11_testing
+++ b/profiles/linux_gcc_11_testing
@@ -1,0 +1,14 @@
+[settings]
+os=Linux
+arch=x86_64
+build_type=Release
+compiler=gcc
+compiler.version=11
+compiler.cppstd=17
+compiler.libcxx=libstdc++11
+[options]
+[conf]
+tools.build:cflags=['-pg', '-fsanitize=address']
+tools.build:cxxflags=['-pg', '-fsanitize=address']
+tools.build:exelinkflags=['-fsanitize=address']
+tools.build:sharedlinkflags=['-fsanitize=address']


### PR DESCRIPTION
Adds a new conan profile to enable profiling and address sanitizer flags on Linux.
To use the profile when building the project, simply specify the profile when calling Conan
`conan build . -pr profiles/linux_gcc_11_testing`