### PR TITLE
Issue817 python39 deprecated in qt installer

### DIFF
--- a/.github/workflows/Build-multi-OS.yml
+++ b/.github/workflows/Build-multi-OS.yml
@@ -90,7 +90,7 @@ jobs:
 
     # This version of Qt only allows python versions in the range 3.6-3.11
     - name: Install Qt
-      uses: jurplel/install-qt-action@master
+      uses: jurplel/install-qt-action@v4
       with:
         version: '6.8.2'
         dir: '${{GITHUB.WORKSPACE}}'

--- a/.github/workflows/Build-multi-OS.yml
+++ b/.github/workflows/Build-multi-OS.yml
@@ -90,7 +90,7 @@ jobs:
 
     # This version of Qt only allows python versions in the range 3.6-3.11
     - name: Install Qt
-      uses: Kidev/install-qt-action@v4.4.2
+      uses: jurplel/install-qt-action@master
       with:
         version: '6.8.2'
         dir: '${{GITHUB.WORKSPACE}}'

--- a/.github/workflows/Build-wheels.yml
+++ b/.github/workflows/Build-wheels.yml
@@ -32,7 +32,7 @@ jobs:
       # 4. <MacOS 14 with arm64 arch, Release, Clang 15 compiler toolchain
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the list.
       matrix: # Qt requires py7zr==0.20.x which requires python 3.7^
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [windows-2022, ubuntu-22.04, macos-13, macos-14]
         include:
           - os: windows-2022
@@ -59,9 +59,6 @@ jobs:
             clang: 15
             build_type: Release
             build_root: build-imagingsuite/Release
-        exclude: # Python 3.7 not supported on ARM architecture
-          - os: macos-14
-            python-version: 3.7
 
     steps:
       # Checkouts the source code to build the project with the git history
@@ -106,7 +103,7 @@ jobs:
 
     # This version of Qt only allows python versions in the range 3.6-3.11 #
     - name: Install Qt
-      uses: Kidev/install-qt-action@v4.4.2
+      uses: jurplel/install-qt-action@master
       with:
         version: '6.8.2'
         dir: '${{GITHUB.WORKSPACE}}'

--- a/.github/workflows/Build-wheels.yml
+++ b/.github/workflows/Build-wheels.yml
@@ -101,9 +101,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install build
 
-    # This version of Qt only allows python versions in the range 3.6-3.11 #
     - name: Install Qt
-      uses: jurplel/install-qt-action@master
+      uses: jurplel/install-qt-action@v4
       with:
         version: '6.8.2'
         dir: '${{GITHUB.WORKSPACE}}'


### PR DESCRIPTION
Jurple has released a new version of his install Qt action, finally implementing the fixes necessary to use Qt 6.8.2. As such this PR reverts to using his official action rather than Kidevs which is a development action. It also drops support for python 3.9 as it has nearly reached its end-of-life and is no longer supported by aqtinstall which the Qt install action relies upon.